### PR TITLE
Avoid using a wildcard in a Menhir production.

### DIFF
--- a/src/parsers/TPTP_parser.mly
+++ b/src/parsers/TPTP_parser.mly
@@ -468,8 +468,8 @@ defined_term:
   | t=defined_atomic_term { t }
 
 defined_atom:
-  | _=INTEGER { Utils.not_implemented "TPTP: cannot handle integer" }
-  | _=RATIONAL { Utils.not_implemented "TPTP: cannot handle rational" }
+  | INTEGER { Utils.not_implemented "TPTP: cannot handle integer" }
+  | RATIONAL { Utils.not_implemented "TPTP: cannot handle rational" }
   | REAL {
       let loc = L.mk_pos $startpos $endpos in
       Parsing_utils.parse_error_ ~loc "TPTP: cannot handle real numbers"
@@ -626,4 +626,3 @@ general_list:
     { A.TPTP.List l }
 
 %%
-


### PR DESCRIPTION
Using a wildcard in this way has never been legal,
but is accepted by Menhir <= 20181026.
It will likely be rejected in the next release of Menhir.

Existing opam package descriptions for nunchaku should be updated to require Menhir <= 20181026.