### PR TITLE
feat: first stab at a cvc5 integration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,6 +14,7 @@ Alternatively, it can use other backends:
 - https://github.com/c-cube/smbc[smbc], a solver written in OCaml, for computational logic
 - kodkod with its https://github.com/nunchaku-inria/kodkodi-pkg[kodkodi frontend]
 - Paradox (https://github.com/c-cube/paradox[snapshot here])
+- cvc5 (after commit [724682fa53aae3d870377065bbe3bed37ae9697c](https://github.com/cvc5/cvc5/commit/724682fa53aae3d870377065bbe3bed37ae9697c))
 
 We have https://github.com/nunchaku-inria/nunchaku-problems[a set of problems]
 for tests and regressions, that can also be helpful to grasp the input syntax

--- a/README.adoc
+++ b/README.adoc
@@ -130,6 +130,7 @@ Supported solver backends:
   http://vlsicad.eecs.umich.edu/BK/Slots/cache/www.cs.chalmers.se/~koen/paradox/[official page])
 - https://github.com/emina/kodkod[Kodkod] with its "kodkodi" parser
 - https://github.com/c-cube/smbc/[SMBC] (`opam install smbc`)
+- https://cvc5.github.io/[CVC5] (after commit b056bd2446cd3e7b8dd4fdc76b87ed0ea3b4aef0)
 
 
 === How to make a release

--- a/bench/benchexec/config.xml
+++ b/bench/benchexec/config.xml
@@ -7,6 +7,10 @@
            hardtimelimit="3s"
            memlimit="1000 MB">
 
+<rundefinition name="cvc5">
+  <option name="-s">cvc5</option>
+</rundefinition>
+
 <rundefinition name="cvc4">
   <option name="-s">cvc4</option>
 </rundefinition>

--- a/src/backends/CVC4.ml
+++ b/src/backends/CVC4.ml
@@ -307,6 +307,7 @@ let pp_problem out (decode, pb) =
         Var.pp_full v pp_ty (Var.ty v) pp_term f
 
   and pp_statement out = function
+    | FO.TyAlias _ -> assert false
     | FO.TyDecl (id,arity,_) ->
       fpf out "(@[declare-sort@ %a@ %d@])" pp_id id arity
     | FO.Decl (v,ty,_) ->
@@ -777,6 +778,7 @@ let preprocess pb : processed_problem =
   let pb =
     FO.Problem.flat_map ~meta:(FO.Problem.meta pb)
       (fun stmt -> match stmt with
+         | FO.TyAlias _ -> assert false
          | FO.Decl (id,(args,_),_) ->
            let len = List.length args in
            begin if len=0

--- a/src/backends/Cvc5.ml
+++ b/src/backends/Cvc5.ml
@@ -701,7 +701,7 @@ let read_res_ ~info ~print_model ~decode s =
 
 (* the set of options given to every instance of cvc5 *)
 let basic_options =
-  "--lang smt --uf-ss-fair-monotone --no-condense-function-values"
+  "--lang smt --finite-model-find"
 
 let mk_info ~options (decode : decode_state) : Res.info =
   let time = Utils.Time.get_timer decode.timer in
@@ -865,13 +865,13 @@ let is_available () =
     res
   with Sys_error _ -> false
 
-(* TODO: Ask cvc5 team about wich options to use for portfolio *)
 let options_l =
   [
-    "";
-    "--uf-ss=no-minimal --decision=internal";
-    "--uf-ss=none";
     "--fmf-mbqi=none";
+    "--decision=internal";
+    "--macros-quant --macros-quant-mode=all";
+    "--e-matching";
+    "--mbqi --fmf-mbqi=none";
   ]
 
 (* solve problem using cvc5 before [deadline] *)

--- a/src/backends/Cvc5.ml
+++ b/src/backends/Cvc5.ml
@@ -1,0 +1,923 @@
+(* This file is free software, part of nunchaku. See file "license" for more details. *)
+
+(** {1 Interface to cvc5} *)
+
+open Nunchaku_core
+module E = CCResult
+module Res = Problem.Res
+module S = Scheduling
+
+type id = ID.t
+
+let name = "cvc5"
+let section = Utils.Section.make name
+let fpf = Format.fprintf
+
+type model_term = FO.T.t
+type model_ty = FO.Ty.t
+
+module DSexp = Sexp_lib.Decoder
+
+exception Error of string
+exception Backend_err of string
+
+let error_ e = raise (Error e)
+let errorf_ fmt = CCFormat.ksprintf fmt ~f:error_
+let cvc5_error_ msg = raise (Backend_err msg)
+let cvc5_errorf_ msg = CCFormat.ksprintf ~f:cvc5_error_ "@[in cvc5:@ %s@]" msg
+
+let () =
+  Printexc.register_printer (function
+    | Error msg ->
+        Some (Utils.err_sprintf "@[in the interface to cvc5:@ %s@]" msg)
+    | _ -> None)
+
+module T = FO.T
+module Ty = FO.Ty
+
+type problem = (T.t, Ty.t) FO.Problem.t
+type symbol_kind = Model.symbol_kind
+
+type decoded_sym =
+  | ID of id (* regular fun *)
+  | De_bruijn of int * Ty.t (* index to mu-binder *)
+  | DataTest of id
+  | DataSelect of id * int
+
+(* a ground type, such as [to a (list b)] *)
+type ground_ty = Ty.t
+
+let gty_make = Ty.app
+let gty_const id = gty_make id []
+
+module GTy_map = CCMap.Make (FO.Ty)
+
+let gty_head ty =
+  match Ty.view ty with FO.TyApp (id, _) -> Some id | FO.TyBuiltin _ -> None
+
+let rec fobackty_of_ground_ty g =
+  match Ty.view g with
+  | FO.TyApp (id, l) -> Ty.app id (List.map fobackty_of_ground_ty l)
+  | FO.TyBuiltin b -> Ty.builtin b
+
+type model_query =
+  | Q_const
+  (* we want to know the value of this constant *)
+  | Q_fun of int
+  (* we want to know the value of this function (int: arity) *)
+  | Q_type of ground_ty
+(* [id -> ty] means that [id : ty] is a dummy value, and we  want
+     to know the finite domain of [ty] by asking [get-model-domain-elements] *)
+
+let is_simple_query q =
+  match q with Q_const | Q_fun _ -> true | Q_type _ -> false
+
+let is_card_query q =
+  match q with Q_const | Q_fun _ -> false | Q_type _ -> true
+
+type decode_state = {
+  kinds : symbol_kind ID.Map.t;
+  (* ID -> its kind *)
+  id_to_name : string ID.Tbl.t;
+  (* maps ID to unique names *)
+  name_to_id : (string, decoded_sym) Hashtbl.t;
+  (* map (stringof ID) -> ID, and other builtins *)
+  symbols : model_query ID.Tbl.t;
+  (* set of symbols to ask values for in the model *)
+  vars : Ty.t Var.t ID.Tbl.t;
+  (* variables in scope *)
+  let_vars : (string, model_term) Hashtbl.t;
+  (* let variables in scope together with their value *)
+  db_prefixes : (string, ground_ty) Hashtbl.t;
+  (* prefixes expected for De Bruijn indices *)
+  timer : Utils.Time.timer;
+  (* time elapsed *)
+  mutable db_stack : Ty.t Var.t option ref list;
+  (* stack of variables for mu-binders, with a bool ref.
+     If the ref is true, it means the variable is used at least once *)
+  mutable witnesses : ID.t GTy_map.t; (* type -> witness of this type *)
+}
+
+let create_decode_state ~kinds () =
+  {
+    kinds;
+    id_to_name = ID.Tbl.create 32;
+    name_to_id = Hashtbl.create 32;
+    symbols = ID.Tbl.create 32;
+    db_prefixes = Hashtbl.create 8;
+    db_stack = [];
+    timer = Utils.Time.start_timer ();
+    vars = ID.Tbl.create 32;
+    let_vars = Hashtbl.create 32;
+    witnesses = GTy_map.empty;
+  }
+
+(* the solver is dealt with through stdin/stdout *)
+type t = {
+  oc : out_channel;
+  fmt : Format.formatter; (* prints on [oc] *)
+  ic : in_channel;
+  decode : decode_state;
+  print_model : bool;
+  options : string;
+  sexp : DSexp.t;
+  mutable closed : bool;
+  mutable res : (T.t, Ty.t) Problem.Res.t option;
+}
+
+let name = "cvc5"
+
+let close s =
+  if not s.closed then (
+    s.closed <- true;
+    (* quite cvc5 and stop process *)
+    try
+      Format.pp_print_flush s.fmt ();
+      output_string s.oc "(exit)\n";
+      flush s.oc;
+      close_in_noerr s.ic;
+      close_out_noerr s.oc
+    with _ -> ())
+
+let create_ ~options ~print_model ~decode (ic, oc) =
+  (* the [t] instance *)
+  let s =
+    {
+      oc;
+      fmt = Format.formatter_of_out_channel oc;
+      ic;
+      options;
+      print_model;
+      decode;
+      closed = false;
+      sexp = DSexp.of_lexbuf (Lexing.from_channel ic);
+      res = None;
+    }
+  in
+  Gc.finalise close s;
+  (* close on finalize *)
+  s
+
+let pp_list ?(sep = " ") pp = Utils.pp_list ~sep pp
+
+(* add numeric suffix to [name] until it is an unused name *)
+let find_unique_name_ ~decode name0 =
+  if not (Hashtbl.mem decode.name_to_id name0) then name0
+  else
+    let n = ref 0 in
+    while Hashtbl.mem decode.name_to_id (Printf.sprintf "%s_%d" name0 !n) do
+      incr n
+    done;
+    Printf.sprintf "%s_%d" name0 !n
+
+(* injection from ID to string *)
+let id_to_name ~decode id =
+  try ID.Tbl.find decode.id_to_name id
+  with Not_found ->
+    let name0 =
+      match (ID.name id, ID.polarity id) with
+      | s, Polarity.NoPol -> s ^ "_" (* avoid clashes with cvc5 builtins *)
+      | s, Polarity.Pos -> s ^ "_+"
+      | s, Polarity.Neg -> s ^ "_-"
+    in
+    let name = find_unique_name_ ~decode name0 in
+    Hashtbl.add decode.name_to_id name (ID id);
+    ID.Tbl.add decode.id_to_name id name;
+    name
+
+let pp_builtin_cvc5 out = function
+  | `Unitype -> assert false
+  | `Prop -> CCFormat.string out "Bool"
+
+(* print ground type using cvc5's escaping rules *)
+let rec pp_gty ~decode out g =
+  let normalize_str =
+    String.map (fun c ->
+        match c with 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> c | _ -> '_')
+  in
+  match Ty.view g with
+  | FO.TyBuiltin b -> pp_builtin_cvc5 out b
+  | FO.TyApp (id, []) ->
+      CCFormat.string out (id_to_name ~decode id |> normalize_str)
+  | FO.TyApp (id, l) ->
+      fpf out "_%s_%a_"
+        (id_to_name ~decode id |> normalize_str)
+        (pp_list ~sep:"_" (pp_gty ~decode))
+        l
+
+(* the prefix used by cvc5 for constants of the given type *)
+let const_of_ty ~decode gty =
+  CCFormat.sprintf "@[<h>@@%a@]" (pp_gty ~decode) gty
+
+(* the i-th constant of the given type *)
+let const_of_ty_nth ~decode gty i =
+  CCFormat.sprintf "@[<h>%s_%d@]" (const_of_ty ~decode gty) i
+
+let get_ty_witness ~decode gty =
+  try GTy_map.find gty decode.witnesses
+  with Not_found ->
+    errorf_ "no witness declared for cardinality bound on %a" (pp_gty ~decode)
+      gty
+
+(* print processed problem *)
+let pp_problem out (decode, pb) =
+  (* print ID and remember its name for parsing model afterward *)
+  let rec pp_id out id =
+    (* find a unique name for this ID *)
+    let name = id_to_name ~decode id in
+    CCFormat.string out name
+  (* print [is-c] for a constructor [c] *)
+  and pp_tester out c =
+    let name = Printf.sprintf "is-%s" (id_to_name ~decode c) in
+    Hashtbl.replace decode.name_to_id name (DataTest c);
+    CCFormat.string out name
+  (* print [select-c-n] to select the n-th argument of [c] *)
+  and pp_select out (c, n) =
+    let name = Printf.sprintf "_select_%s_%d" (id_to_name ~decode c) n in
+    Hashtbl.replace decode.name_to_id name (DataSelect (c, n));
+    CCFormat.string out name
+  (* print type (a monomorphic type) in SMT *)
+  and pp_ty out ty =
+    match Ty.view ty with
+    | FO.TyBuiltin b -> pp_builtin_cvc5 out b
+    | FO.TyApp (f, []) -> pp_id out f
+    | FO.TyApp (f, l) -> fpf out "@[(%a@ %a)@]" pp_id f (pp_list pp_ty) l
+  (* print type in SMT syntax *)
+  and pp_ty_decl out ty =
+    let args, ret = ty in
+    fpf out "%a %a" (CCFormat.within "(" ")" (pp_list pp_ty)) args pp_ty ret
+  and pp_term out t =
+    match T.view t with
+    | FO.Builtin b -> ( match b with `Int n -> CCFormat.int out n)
+    | FO.Var v -> Var.pp_full out v
+    | FO.App (f, []) -> pp_id out f
+    | FO.App (f, l) -> fpf out "(@[%a@ %a@])" pp_id f (pp_list pp_term) l
+    | FO.DataTest (c, t) -> fpf out "(@[%a@ %a@])" pp_tester c pp_term t
+    | FO.DataSelect (c, n, t) ->
+        fpf out "(@[%a@ %a@])" pp_select (c, n) pp_term t
+    | FO.Undefined t -> pp_term out t (* tailcall, probably *)
+    | FO.Undefined_atom _ -> errorf_ "cannot print `undefined_atom` in SMTlib"
+    | FO.Unparsable _ -> errorf_ "cannot print `unparsable` in SMTlib"
+    | FO.Card_at_least (_, n) when n <= 1 -> fpf out "true" (* trivial *)
+    | FO.Card_at_least (ty, n) ->
+        let witness = get_ty_witness ~decode ty in
+        fpf out "(@[(not (_ fmf.card %a %d))@])" pp_id witness (n - 1)
+    | FO.Fun (v, t) ->
+        fpf out "@[<3>(LAMBDA@ ((%a %a))@ %a)@]" Var.pp_full v pp_ty (Var.ty v)
+          pp_term t
+    | FO.Let (v, t, u) ->
+        fpf out "@[<3>(let@ ((%a %a))@ %a@])" Var.pp_full v pp_term t pp_term u
+    | FO.Mu _ -> Utils.not_implemented "cannot send MU-term to CVC4"
+    | FO.Ite (a, b, c) ->
+        fpf out "@[<2>(ite@ %a@ %a@ %a)@]" pp_term a pp_term b pp_term c
+    | FO.True -> CCFormat.string out "true"
+    | FO.False -> CCFormat.string out "false"
+    | FO.Eq (a, b) -> fpf out "(@[=@ %a@ %a@])" pp_term a pp_term b
+    | FO.And [] -> CCFormat.string out "true"
+    | FO.And [ f ] -> pp_term out f
+    | FO.And l -> fpf out "(@[and@ %a@])" (pp_list pp_term) l
+    | FO.Or [] -> CCFormat.string out "false"
+    | FO.Or [ f ] -> pp_term out f
+    | FO.Or l -> fpf out "(@[or@ %a@])" (pp_list pp_term) l
+    | FO.Not f -> fpf out "(@[not@ %a@])" pp_term f
+    | FO.Imply (a, b) -> fpf out "(@[=>@ %a@ %a@])" pp_term a pp_term b
+    | FO.Equiv (a, b) -> fpf out "(@[=@ %a@ %a@])" pp_term a pp_term b
+    | FO.Forall (v, f) ->
+        fpf out "(@[<2>forall@ ((%a %a))@ %a@])" Var.pp_full v pp_ty (Var.ty v)
+          pp_term f
+    | FO.Exists (v, f) ->
+        fpf out "(@[<2>exists@ ((%a %a))@ %a@])" Var.pp_full v pp_ty (Var.ty v)
+          pp_term f
+  and pp_statement out = function
+    | FO.TyAlias (id, ty, _) ->
+        fpf out "(@[define-sort@ %a@ %a@])" pp_id id pp_ty_decl ty
+    | FO.TyDecl (id, arity, _) ->
+        fpf out "(@[declare-sort@ %a@ %d@])" pp_id id arity
+    | FO.Decl (v, ty, _) ->
+        fpf out "(@[<2>declare-fun@ %a@ %a@])" pp_id v pp_ty_decl ty
+    | FO.Axiom t -> fpf out "(@[assert@ %a@])" pp_term t
+    | FO.Goal t -> fpf out "(@[assert@ %a@])" pp_term t
+    | FO.CardBound (ty_id, which, n) -> (
+        let witness = get_ty_witness ~decode (gty_const ty_id) in
+        let pp_max_card out n =
+          if n < 1 then fpf out "(assert false)" (* absurd *)
+          else fpf out "(@[assert (_ fmf.card %a %d)@])" pp_id witness n
+        and pp_min_card out n =
+          if n <= 1 then ()
+          else
+            fpf out "(@[assert (not (_ fmf.card %a %d))@])" pp_id witness (n - 1)
+        in
+        match which with `Max -> pp_max_card out n | `Min -> pp_min_card out n)
+    | FO.MutualTypes (k, l) -> pp_mutual_types out k l
+  and pp_mutual_types out k l =
+    let pp_arg out (c, i, ty) =
+      fpf out "(@[<h>%a %a@])" pp_select (c, i) pp_ty ty
+    in
+    let pp_cstor out c =
+      (* add selectors *)
+      let args =
+        List.mapi (fun i ty -> (c.FO.cstor_name, i, ty)) c.FO.cstor_args
+      in
+      fpf out "(@[<2>%a@ %a@])" pp_id c.FO.cstor_name (pp_list pp_arg) args
+    in
+    let n_vars = List.length l.FO.tys_vars in
+    let pp_tydef out tydef =
+      let cstors = ID.Map.to_list tydef.FO.ty_cstors |> List.map snd in
+      if l.FO.tys_vars = [] then fpf out "(@[%a@])" (pp_list pp_cstor) cstors
+      else
+        fpf out "(@[par (@[%a@])@ (@[%a@])@])" (pp_list pp_id) l.FO.tys_vars
+          (pp_list pp_cstor) cstors
+    and pp_decl out tydef =
+      fpf out "(@[%a@ %d@])" pp_id tydef.FO.ty_name n_vars
+    in
+    fpf out "(@[<2>%s@ (@[%a@])@ (@[<hv>%a@])@])"
+      (match k with
+      | `Data -> "declare-datatypes"
+      | `Codata -> "declare-codatatypes")
+      (pp_list pp_decl) l.FO.tys_defs (pp_list pp_tydef) l.FO.tys_defs
+  in
+  (* send prelude *)
+  fpf out "@[<v>";
+  fpf out "(set-option :produce-models true)@,";
+  fpf out "(set-option :interactive-mode true)@,";
+  fpf out "(set-option :finite-model-find true)@,";
+  fpf out "(set-logic UFCDT)@,";
+  (* write problem *)
+  Utils.pp_iter ~sep:"" pp_statement out
+    (CCVector.to_iter pb.FO.Problem.statements);
+  fpf out "@,(check-sat)@]@.";
+  ()
+
+let send_ s problem =
+  fpf s.fmt "%a@." pp_problem (s.decode, problem);
+  Format.pp_print_flush s.fmt ();
+  ()
+
+let find_atom_ ~decode s =
+  try Hashtbl.find decode.name_to_id s
+  with Not_found ->
+    (* introduced by cvc5 in the model; make a new ID *)
+    let id = ID.make s in
+    Hashtbl.replace decode.name_to_id s (ID id);
+    ID id
+
+(* parse an identifier *)
+let parse_atom_ ~decode = function
+  | `Atom s -> (
+      match CCString.Split.right ~by:"_" s with
+      | None -> find_atom_ ~decode s
+      | Some (pre, n) -> (
+          (* might be a De Bruijn index *)
+          try
+            let ty = Hashtbl.find decode.db_prefixes pre in
+            let n = int_of_string n in
+            De_bruijn (n, ty)
+          with Not_found -> find_atom_ ~decode s))
+  | _ -> error_ "expected ID, got a list"
+
+let parse_id_ ~decode s =
+  match parse_atom_ ~decode s with
+  | ID id -> id
+  | De_bruijn _ | DataTest _ | DataSelect _ ->
+      error_ "expected ID, got data test/select/de bruijn"
+
+(* parse an atomic type *)
+let rec parse_ty_ ~decode = function
+  | `Atom "Bool" -> Ty.builtin `Prop
+  | `Atom _ as f ->
+      let id = parse_id_ ~decode f in
+      Ty.const id
+  | `List ((`Atom _ as f) :: l) ->
+      let id = parse_id_ ~decode f in
+      let l = List.map (parse_ty_ ~decode) l in
+      Ty.app id l
+  | _ -> error_ "invalid type"
+
+let parse_var_ ~decode = function
+  | `List [ (`Atom _ as v); ty ] ->
+      let id = parse_id_ ~decode v in
+      let ty = parse_ty_ ~decode ty in
+      Var.of_id ~ty id
+  | _ -> error_ "expected typed variable"
+
+let parse_int_ = function
+  | `Atom n -> ( try int_of_string n with _ -> error_ "expected int")
+  | `List _ -> error_ "expected int"
+
+(* parse a ground term *)
+let rec parse_term_ ~decode s =
+  let r = ref None in
+  (* maybe, a mu-variable *)
+  decode.db_stack <- r :: decode.db_stack;
+  let res =
+    CCFun.finally
+      ~h:(fun () -> decode.db_stack <- List.tl decode.db_stack)
+      ~f:(fun () -> parse_term_sub_ ~decode s)
+  in
+  match !r with None -> res | Some v -> T.mu v res (* introduce a mu binder *)
+
+and parse_term_sub_ ~decode = function
+  | `Atom "true" -> T.true_
+  | `Atom "false" -> T.false_
+  | `Atom s as t -> (
+      match Hashtbl.find_opt decode.let_vars s with
+      | Some v -> v
+      | None -> (
+          match parse_atom_ ~decode t with
+          | ID id -> (
+              (* can be a constant or a variable, depending on scoping *)
+              try T.var (ID.Tbl.find decode.vars id)
+              with Not_found -> T.const id)
+          | De_bruijn (n, ty) -> (
+              (* adjust: the current term, i.e. the constant, doesn't have
+               a binder, so its stack slot should not count *)
+              let n = n + 1 in
+              match CCList.get_at_idx n decode.db_stack with
+              | None -> errorf_ "De Bruijn index %d not bound" n
+              | Some r -> (
+                  match !r with
+                  | Some v -> T.var v (* use same variable *)
+                  | None ->
+                      (* introduce new variable *)
+                      let v = Var.make ~ty ~name:"self" in
+                      r := Some v;
+                      T.var v))
+          | DataTest _ | DataSelect _ ->
+              error_ "expected ID, got data test/select"))
+  | `List [ `Atom ("LAMBDA" | "lambda"); `List bindings; body ] ->
+      (* lambda term *)
+      let bindings = List.map (parse_var_ ~decode) bindings in
+      (* enter scope of variables *)
+      within_scope ~decode bindings (fun () ->
+          let body = parse_term_ ~decode body in
+          List.fold_right T.fun_ bindings body)
+  | `List [ `Atom "ite"; a; b; c ] ->
+      let a = parse_term_ ~decode a in
+      let b = parse_term_ ~decode b in
+      let c = parse_term_ ~decode c in
+      T.ite a b c
+  | `List [ `Atom "="; a; b ] ->
+      let a = parse_term_ ~decode a in
+      let b = parse_term_ ~decode b in
+      T.eq a b
+  | `List [ `Atom "not"; f ] ->
+      let f = parse_term_ ~decode f in
+      T.not_ f
+  | `List (`Atom "and" :: l) -> T.and_ (List.map (parse_term_ ~decode) l)
+  | `List (`Atom "or" :: l) -> T.or_ (List.map (parse_term_ ~decode) l)
+  | `List [ `Atom "forall"; `List bindings; f ] ->
+      let bindings = List.map (parse_var_ ~decode) bindings in
+      within_scope ~decode bindings (fun () ->
+          let f = parse_term_ ~decode f in
+          List.fold_right T.forall bindings f)
+  | `List [ `Atom "exists"; `List bindings; f ] ->
+      let bindings = List.map (parse_var_ ~decode) bindings in
+      within_scope ~decode bindings (fun () ->
+          let f = parse_term_ ~decode f in
+          List.fold_right T.exists bindings f)
+  | `List [ `Atom "=>"; a; b ] ->
+      let a = parse_term_ ~decode a in
+      let b = parse_term_ ~decode b in
+      T.imply a b
+  | `List [ `Atom "as"; term; _sort ] ->
+      (* SMT-LIB 2.7 may wrap a value `v` in `(as v s)` to make its sort `s` explicit *)
+      parse_term_ ~decode term
+  | `List [ `Atom "let"; `List bindings; body ] ->
+      let bindings = List.map (parse_let_binding ~decode) bindings in
+      within_let_scope ~decode bindings (fun () -> parse_term_ ~decode body)
+  | `List ((`Atom s as f) :: l) as sexp -> (
+      match Hashtbl.find_opt decode.let_vars s with
+      | Some _ -> errorf_ "Application of let variable %a" Sexp_lib.pp sexp
+      | None -> (
+          match (parse_atom_ ~decode f, l) with
+          | ID f, _ ->
+              (* regular function app *)
+              let l = List.map (parse_term_ ~decode) l in
+              T.app f l
+          | De_bruijn _, _ -> error_ "invalid arity for De Bruijn index"
+          | DataTest c, [ t ] ->
+              let t = parse_term_ ~decode t in
+              T.data_test c t
+          | DataTest _, _ -> error_ "invalid arity for DataTest"
+          | DataSelect (c, n), [ t ] ->
+              let t = parse_term_ ~decode t in
+              T.data_select c n t
+          | DataSelect _, _ -> error_ "invalid arity for DataSelect"))
+  | `List (`List _ :: _) as s ->
+      errorf_ "non first-order list@ %a" Sexp_lib.pp s
+  | `List [] -> error_ "expected term, got empty list"
+
+and within_scope ~decode bindings f =
+  List.iter (fun v -> ID.Tbl.add decode.vars (Var.id v) v) bindings;
+  CCFun.finally ~f ~h:(fun () ->
+      List.iter (fun v -> ID.Tbl.remove decode.vars (Var.id v)) bindings)
+
+and parse_let_binding ~decode = function
+  | `List [ `Atom id; value ] -> (id, parse_term_ ~decode value)
+  | s ->
+      errorf_ "invalid let variable declaration declaration@ %a" Sexp_lib.pp s
+
+and within_let_scope ~decode bindings f =
+  List.iter (fun (var, value) -> Hashtbl.add decode.let_vars var value) bindings;
+  CCFun.finally ~f ~h:(fun () ->
+      List.iter (fun (var, _) -> Hashtbl.remove decode.let_vars var) bindings)
+
+(* parse a function with [n] arguments *)
+let parse_fun_ ~decode ~arity:n term =
+  (* split [t] into [n]-ary function arguments and body *)
+  let rec get_args t n =
+    if n = 0 then ([], t)
+    else
+      match T.view t with
+      | FO.Fun (v, t') ->
+          let vars, body = get_args t' (n - 1) in
+          (v :: vars, body)
+      | _ -> errorf_ "expected %d-ary function,@ got `@[%a@]`" n FO.pp_term t
+  in
+  (* parse term, then convert into [vars -> decision-tree] *)
+  let t = parse_term_ ~decode term in
+  let vars, body = get_args t n in
+  (* change the shape of [body] so it looks more like a decision tree *)
+  Utils.debugf ~section 1 "@[<2>turn term `@[%a@]`@ @]" (fun k ->
+      k FO.pp_term body);
+  let dt = FO.Util.dt_of_term ~vars body in
+  Utils.debug ~section 1 "END";
+  Utils.debugf ~section 5 "@[<2>turn term `@[%a@]`@ into DT `@[%a@]`@]"
+    (fun k -> k FO.pp_term body (Model.DT.pp FO.pp_term' FO.pp_ty) dt);
+  dt
+
+let sym_get_const_ ~decode id =
+  match ID.Tbl.find decode.symbols id with
+  | Q_const -> `Const
+  | Q_fun n -> `Fun n
+  | Q_type _ -> assert false
+
+let sym_get_ty_ ~decode id =
+  match ID.Tbl.find decode.symbols id with
+  | Q_const | Q_fun _ -> assert false
+  | Q_type ty -> ty
+
+let get_kind ~decode id =
+  try ID.Map.find id decode.kinds
+  with Not_found -> errorf_ "could not find kind of %a" ID.pp id
+
+(* state: decode_state *)
+let parse_simple_model_ ~decode : Sexp_lib.t -> (_, _) Model.t = function
+  | `Atom _ -> error_ "expected model, got atom"
+  | `List assoc ->
+      (* parse model *)
+      let m =
+        List.fold_left
+          (fun m -> function
+            | `List [ (`Atom _ as s); term ] -> (
+                let id = parse_id_ ~decode s in
+                let kind = get_kind ~decode id in
+                match sym_get_const_ ~decode id with
+                | `Const ->
+                    let t = parse_term_ ~decode term in
+                    Model.add_const m (T.const id, t, kind)
+                | `Fun n ->
+                    let dt = parse_fun_ ~decode ~arity:n term in
+                    Model.add_value m (T.const id, dt, kind))
+            | _ -> error_ "expected pair key/value in the model")
+          Model.empty assoc
+      in
+      m
+
+let parse_domain_elems_ : Sexp_lib.t -> int = function
+  | `Atom _ -> error_ "expected list, got atom"
+  | `List assoc -> List.length assoc
+
+let get_finite_domain_ ~print_model decode s witness_id =
+  (* TODO: dedup *)
+  let pp_id out i = CCFormat.string out (ID.Tbl.find decode.id_to_name i) in
+  fpf s.fmt "(@[<hv2>get-model-domain-elements %a@])@." pp_id witness_id;
+  match DSexp.next s.sexp with
+  | `Error e -> error_ e
+  | `End -> error_ "unexpected end of input from cvc5: expected model"
+  | `Ok sexp ->
+      if print_model then
+        Format.eprintf "@[raw domain elements:@ @[<hv>%a@]@]@." Sexp_lib.pp sexp;
+      let gty = sym_get_ty_ ~decode witness_id in
+      let ty = fobackty_of_ground_ty gty in
+      let n =
+        match sexp with
+        | `Atom _ -> error_ "expected list, got atom"
+        | `List assoc -> List.length assoc
+      in
+      let terms =
+        Iter.(
+          0 -- (n - 1)
+          |> map (fun i ->
+                 let name = const_of_ty_nth ~decode gty i in
+                 Utils.debugf ~section 3 "@[building name: %s @]" (fun k ->
+                     k name);
+                 let id =
+                   match find_atom_ ~decode name with
+                   | ID id -> id
+                   | _ -> assert false
+                 in
+                 id)
+          |> to_rev_list)
+      in
+      (ty, terms)
+
+let send_get_simple_model_ out decode =
+  (* print a single symbol *)
+  let pp_id out i = CCFormat.string out (ID.Tbl.find decode.id_to_name i) in
+  let pp_simple_query out (id, q) =
+    match q with Q_const | Q_fun _ -> pp_id out id | Q_type _ -> assert false
+  in
+  fpf out "(@[<hv2>get-value@ (@[<hv>%a@])@])"
+    (Utils.pp_iter ~sep:" " pp_simple_query)
+    (ID.Tbl.to_iter decode.symbols
+    |> Iter.filter (fun (_, q) -> is_simple_query q))
+
+(* read model from cvc5 instance [s] *)
+let get_model_ ~print_model ~decode s : (_, _) Model.t =
+  Utils.debugf ~section 3 "@[<2>ask for simple part of model with@ %a@]"
+    (fun k -> k send_get_simple_model_ decode);
+  fpf s.fmt "%a@." send_get_simple_model_ decode;
+  (* read result back *)
+  let simple_model =
+    match DSexp.next s.sexp with
+    | `Error e -> error_ e
+    | `End -> error_ "unexpected end of input from cvc5: expected model"
+    | `Ok sexp ->
+        if print_model then
+          Format.eprintf "@[raw model:@ @[<hv>%a@]@]@." Sexp_lib.pp sexp;
+        let m = parse_simple_model_ ~decode sexp in
+        m
+  in
+  let m =
+    Iter.(
+      ID.Tbl.to_iter decode.symbols
+      |> filter (fun (_, q) -> is_card_query q)
+      |> map (fun (id, _) -> get_finite_domain_ ~print_model decode s id)
+      |> fold
+           (fun m (ty, terms) -> Model.add_finite_type m ty terms)
+           simple_model)
+  in
+  (* check all symbols are defined *)
+  let ok =
+    List.length m.Model.values + List.length m.Model.finite_types
+    = ID.Tbl.length decode.symbols
+  in
+  if not ok then error_ "some symbols are not defined in the model";
+  m
+
+(* read the result *)
+let read_res_ ~info ~print_model ~decode s =
+  try
+    match DSexp.next s.sexp with
+    | `Ok (`Atom "unsat") ->
+        Utils.debug ~section 5 "cvc5 returned `unsat`";
+        Res.Unsat (Lazy.force info)
+    | `Ok (`Atom "sat") ->
+        Utils.debug ~section 5 "cvc5 returned `sat`";
+        let m =
+          if ID.Tbl.length decode.symbols = 0 then Model.empty
+          else get_model_ ~print_model ~decode s
+        in
+        Res.Sat (m, Lazy.force info)
+    | `Ok (`Atom "unknown") ->
+        Utils.debug ~section 5 "cvc5 returned `unknown`";
+        Res.Unknown [ Res.U_other (Lazy.force info, "") ]
+    | `Ok (`List [ `Atom "error"; `Atom s ]) ->
+        Utils.debugf ~section 5 "@[<2>cvc5 returned `error %s`@]" (fun k -> k s);
+        Res.Unknown [ Res.U_backend_error (Lazy.force info, cvc5_error_ s) ]
+    | `Ok sexp ->
+        let msg =
+          CCFormat.sprintf "@[unexpected answer from cvc5:@ `%a`@]" Sexp_lib.pp
+            sexp
+        in
+        Res.Unknown [ Res.U_backend_error (Lazy.force info, msg) ]
+    | `Error e -> Res.Error (Error e, Lazy.force info)
+    | `End ->
+        Utils.debug ~section 5 "no answer from cvc5, assume it timeouted";
+        Res.Unknown [ Res.U_timeout (Lazy.force info) ]
+  with Backend_err msg ->
+    Res.Unknown [ Res.U_backend_error (Lazy.force info, msg) ]
+
+(* the set of options given to every instance of cvc5 *)
+let basic_options =
+  "--lang smt --uf-ss-fair-monotone --no-condense-function-values"
+
+let mk_info ~options (decode : decode_state) : Res.info =
+  let time = Utils.Time.get_timer decode.timer in
+  let message = Printf.sprintf "options: `%s %s`" basic_options options in
+  Res.mk_info ~backend:"cvc5" ~time ~message ()
+
+let res t =
+  match t.res with
+  | Some r -> r
+  | None when t.closed ->
+      let r =
+        Res.Unknown [ Res.U_timeout (mk_info ~options:t.options t.decode) ]
+      in
+      t.res <- Some r;
+      r
+  | None ->
+      let info = lazy (mk_info ~options:t.options t.decode) in
+      let r =
+        try read_res_ ~info ~print_model:t.print_model ~decode:t.decode t
+        with e -> Res.Error (e, Lazy.force info)
+      in
+      t.res <- Some r;
+      r
+
+(* once processed, the problem also contains the set of symbols to
+   read back from the model, and type witnesses *)
+type processed_problem = decode_state * problem
+
+(* is [ty] a finite (uninterpreted) type? *)
+let is_finite_ decode ty =
+  match Ty.view ty with
+  | FO.TyApp (id, _) -> get_kind ~decode id = Model.Symbol_utype
+  | _ -> false
+
+(* does two things:
+    - add some witness alias sorts for uninterpreted types (for asking for
+        the type's domain later)
+    - compute the set of symbols for which we want the model's value *)
+let preprocess pb : processed_problem =
+  let kinds = FO.Util.problem_kinds pb in
+  let n = ref 0 in
+  let state = create_decode_state ~kinds () in
+  let decl state id c = ID.Tbl.add state.symbols id c in
+  let add_db_prefix state c ty = Hashtbl.replace state.db_prefixes c ty in
+  (* if some types in [l] do not have a witness, add them to [[stmt]] *)
+  let add_ty_witnesses stmt l =
+    List.fold_left
+      (fun acc gty ->
+        if (not (is_finite_ state gty)) || GTy_map.mem gty state.witnesses then
+          acc
+          (* already declared a witness for [gty], or [gty] is not
+                     a finite type *)
+        else
+          (* add a dummy constant *)
+          let c = ID.make (CCFormat.sprintf "__nun_card_witness_%d" !n) in
+          incr n;
+          (* declare [c] *)
+          let ty_c = ([], gty) in
+          decl state c (Q_type gty);
+          state.witnesses <- GTy_map.add gty c state.witnesses;
+          FO.TyAlias (c, ty_c, []) :: acc)
+      [ stmt ] l
+    |> List.rev
+  in
+  (* gather list of (possibly parametrized) types occurring in [stmt],
+     add witnesses for them *)
+  let add_ty_witnesses_gen stmt =
+    let tys =
+      FO.tys_of_statement stmt
+      |> Iter.flat_map FO.Ty.to_iter
+      |> Iter.sort_uniq ~cmp:FO.Ty.compare
+      |> Iter.to_rev_list
+    in
+    add_ty_witnesses stmt tys
+  in
+  let pb =
+    FO.Problem.flat_map ~meta:(FO.Problem.meta pb)
+      (fun stmt ->
+        match stmt with
+        | FO.TyAlias (_, _, _) -> assert false
+        | FO.Decl (id, (args, _), _) ->
+            let len = List.length args in
+            if len = 0 then decl state id Q_const else decl state id (Q_fun len);
+            (* if args contains composite types, add witnesses for them *)
+            add_ty_witnesses stmt args
+        | FO.CardBound (id, _, _) | FO.TyDecl (id, 0, _) ->
+            add_ty_witnesses stmt [ gty_const id ]
+        | FO.MutualTypes (`Codata, l) ->
+            List.iter
+              (fun tydef ->
+                (* use De Bruijn prefixes *)
+                let ty = gty_const tydef.FO.ty_name in
+                let c = const_of_ty ~decode:state ty in
+                Utils.debugf ~section 5
+                  "@[<2>declare `%s` as De Bruijn prefix@]" (fun k -> k c);
+                add_db_prefix state c ty)
+              l.FO.tys_defs;
+            add_ty_witnesses_gen stmt
+        | FO.TyDecl _ (* witnesses will be added on demand *) | FO.Axiom _
+        | FO.Goal _
+        | FO.MutualTypes (_, _) ->
+            add_ty_witnesses_gen stmt)
+      pb
+  in
+  (state, pb)
+
+(* the command line to invoke cvc5 *)
+let mk_cvc5_cmd_ timeout options =
+  let timeout_hard = int_of_float (timeout +. 1.50001) in
+  let timeout_ms = int_of_float (timeout *. 1000.) in
+  Printf.sprintf "ulimit -t %d; exec cvc5 --tlimit=%d %s %s" timeout_hard
+    timeout_ms basic_options options
+
+let solve ?(options = "") ?deadline ?(print = false) ?(print_model = false) pb =
+  let now = Unix.gettimeofday () in
+  let deadline = match deadline with Some s -> s | None -> now +. 30. in
+  (* preprocess first *)
+  let decode, problem' = preprocess pb in
+  if print then
+    Format.printf "@[<v2>SMT problem:@ %a@]@." pp_problem (decode, problem');
+  (* enough time remaining? *)
+  if now +. 0.1 > deadline then
+    let message = Printf.sprintf "options: `%s`" options in
+    let info = Res.mk_info ~backend:"cvc5" ~time:0. ~message () in
+    S.Fut.return (Res.Unknown [ Res.U_timeout info ], S.No_shortcut)
+  else (
+    Utils.debug ~section 1 "calling cvc5";
+    let timeout = deadline -. now in
+    assert (timeout > 0.);
+    let cmd = mk_cvc5_cmd_ timeout options in
+    S.popen cmd ~f:(fun (oc, ic) ->
+        let s = create_ ~options ~print_model ~decode (ic, oc) in
+        send_ s problem';
+        let r = res s in
+        Utils.debugf ~lock:true ~section 3 "@[<2>result: %a@]" (fun k ->
+            k (Res.pp FO.pp_term' FO.pp_ty) r);
+        close s;
+        match r with
+        | Res.Sat (_, _) -> (r, S.Shortcut)
+        | Res.Unsat i ->
+            (* beware, this "unsat" might be wrong *)
+            if pb.FO.Problem.meta.ProblemMetadata.unsat_means_unknown then
+              (Res.Unknown [ Res.U_incomplete i ], S.No_shortcut)
+            else (Res.Unsat i, S.Shortcut)
+        | Res.Unknown _ -> (r, S.No_shortcut)
+        | Res.Error (e, _) ->
+            Utils.debugf ~lock:true ~section 1
+              "@[<2>error while running cvc5@ with `%s`:@ @[%s@]@]" (fun k ->
+                k cmd (Printexc.to_string e));
+            (r, S.Shortcut))
+    |> S.Fut.map (function
+         | E.Ok x -> fst x
+         | E.Error e ->
+             let info = mk_info ~options decode in
+             (Res.Error (e, info), S.Shortcut)))
+
+let is_available () =
+  try
+    let res = Sys.command "which cvc5 > /dev/null 2> /dev/null" = 0 in
+    if res then Utils.debug ~section 3 "cvc5 is available";
+    res
+  with Sys_error _ -> false
+
+(* TODO: Ask cvc5 team about wich options to use for portfolio *)
+let options_l =
+  [
+    "";
+    "--uf-ss=no-minimal --decision=internal";
+    "--uf-ss=none";
+    "--fmf-mbqi=none";
+  ]
+
+(* solve problem using cvc5 before [deadline] *)
+let call ?(options = "") ?prio ?slice ~print ~dump ~print_smt ~print_model
+    problem =
+  if print then Format.printf "@[<v2>FO problem:@ %a@]@." FO.pp_problem problem;
+  match dump with
+  | None ->
+      Scheduling.Task.of_fut ?prio ?slice (fun ~deadline () ->
+          solve ~options ~deadline ~print:print_smt ~print_model problem)
+  | Some file ->
+      let file = file ^ ".cvc5.smt2" in
+      Utils.debugf ~section 1 "output cvc5 problem into `%s`" (fun k -> k file);
+      let info =
+        CCIO.with_out file (fun oc ->
+            let out = Format.formatter_of_out_channel oc in
+            let decode, problem' = preprocess problem in
+            Format.fprintf out "@[<v>; generated by Nunchaku@ %a@]@." pp_problem
+              (decode, problem');
+            mk_info ~options decode)
+      in
+      S.Task.return (Res.Unknown [ Res.U_other (info, "--dump") ]) S.No_shortcut
+
+let pipes ?(options = [ "" ]) ?slice ?(schedule_options = true) ~print ~dump
+    ~print_smt ~print_model () =
+  let slice =
+    if schedule_options then (
+      let n = List.length options in
+      assert (n > 0);
+      (* each process' slice is only [1/n] of the global cvc5 slice *)
+      CCOption.map (fun s -> s /. float n) slice)
+    else slice
+  in
+  let encode pb =
+    ( List.mapi
+        (fun i options ->
+          (* only print for the first task *)
+          let print = print && i = 0 in
+          let print_smt = print_smt && i = 0 in
+          let prio = 30 + (10 * i) in
+          call ?slice ~options ~prio ~print ~dump ~print_smt ~print_model pb)
+        options,
+      () )
+  in
+  let input_spec =
+    Transform.Features.(
+      of_list [ (Ty, Mono); (Eqn, Absent); (Copy, Absent); (Match, Absent) ])
+  in
+  Transform.make ~input_spec ~name ~encode ~decode:(fun _ x -> x) ()

--- a/src/backends/Cvc5.mli
+++ b/src/backends/Cvc5.mli
@@ -17,6 +17,7 @@ val solve :
   ?deadline:float ->
   ?print:bool ->
   ?print_model:bool ->
+  env:(model_term, model_ty) FO.Env.t ->
   problem ->
   ((model_term, model_ty) Problem.Res.t * Scheduling.shortcut) Scheduling.Fut.t
 (** [solve pb] returns a {b task} that, when executed, will return a model or
@@ -40,6 +41,7 @@ val call :
   dump:string option ->
   print_smt:bool ->
   print_model:bool ->
+  env:(model_term, model_ty) FO.Env.t ->
   problem ->
   (model_term, model_ty) Problem.Res.t Scheduling.Task.t
 (** Task for running cvc5 on a problem, with a set of options

--- a/src/backends/Cvc5.mli
+++ b/src/backends/Cvc5.mli
@@ -1,0 +1,75 @@
+(* This file is free software, part of nunchaku. See file "license" for more details. *)
+
+(** {1 Interface to cvc5} *)
+
+open Nunchaku_core
+
+type model_term = FO.T.t
+type model_ty = FO.Ty.t
+type problem = (model_term, model_ty) FO.Problem.t
+type processed_problem
+
+val preprocess : problem -> processed_problem
+val pp_problem : Format.formatter -> processed_problem -> unit
+
+val solve :
+  ?options:string ->
+  ?deadline:float ->
+  ?print:bool ->
+  ?print_model:bool ->
+  problem ->
+  ((model_term, model_ty) Problem.Res.t * Scheduling.shortcut) Scheduling.Fut.t
+(** [solve pb] returns a {b task} that, when executed, will return a model or
+    UNSAT (see {!Solver_intf.Res.t}). *)
+
+val is_available : unit -> bool
+(** test whether the solver is available (e.g. if the library is installed, or
+    the binary in the path) *)
+
+exception Error of string
+(** Error in the interface to cvc5 *)
+
+val options_l : string list
+(** list of different available options, starting with "" *)
+
+val call :
+  ?options:string ->
+  ?prio:int ->
+  ?slice:float ->
+  print:bool ->
+  dump:string option ->
+  print_smt:bool ->
+  print_model:bool ->
+  problem ->
+  (model_term, model_ty) Problem.Res.t Scheduling.Task.t
+(** Task for running cvc5 on a problem, with a set of options
+    @return a tasks
+    @param options: flags to pass the solver (default "").
+    @param slice total amount of time allotted to cvc5
+    @param prio priority of the task
+    @param dump
+      if [Some f], do not call the solver, but write the problem into file [f]
+    @raise Cvc5_error if the solver failed with an error *)
+
+val pipes :
+  ?options:string list ->
+  ?slice:float ->
+  ?schedule_options:bool ->
+  print:bool ->
+  dump:string option ->
+  print_smt:bool ->
+  print_model:bool ->
+  unit ->
+  ( problem,
+    (model_term, model_ty) Problem.Res.t Scheduling.Task.t list,
+    'c,
+    'c )
+  Transform.transformation
+(** Transformation corresponding to calling cvc5 on the input problem, with each
+    set of option in [options].
+
+    @param schedule_options
+      if [true], then the time slice will be divided into smaller slices. Each
+      slice is used by an instance of cvc5 with different parameters. Disable if
+      you want the first instance(s) cvc5 to potentially use the full amount of
+      time. *)

--- a/src/core/FO.mli
+++ b/src/core/FO.mli
@@ -163,6 +163,29 @@ module T : sig
   (** subterms *)
 end
 
+(** {2 Environment} *)
+module Env : sig
+  type (+'t, +'ty) def =
+    | Cstor
+    | Other
+
+  type (+'t, +'ty) info = {
+    def: ('t, 'ty) def;
+  }
+
+  type ('t, 'ty) t = private {
+    infos: ('t, 'ty) info ID.PerTbl.t;
+  }
+
+  exception UndefinedID of ID.t
+
+  val create: ?size:int -> unit -> (_,_) t
+  val find_exn : env:('t, 'ty) t -> id -> ('t, 'ty) info
+  val is_cstor : (_,_) info -> bool
+
+  val add_statement : env:('t,'ty) t -> ('t,'ty) statement -> ('t,'ty) t
+end
+
 (** {2 Problem} *)
 module Problem : sig
   type ('t, 'ty) t = {
@@ -192,6 +215,7 @@ module Problem : sig
     'acc * ('t2, 'ty2) t
 
   val to_iter : ('t,'ty) t -> ('t,'ty) statement Iter.t
+  val env : ?init:('t,'ty) Env.t -> ('t, 'ty) t -> ('t,'ty) Env.t
 end
 
 (** {2 Utils} *)
@@ -202,6 +226,13 @@ module Util : sig
     (T.t, Ty.t) Model.DT.t
   (** Convert a term into a decision tree, or emit a warning and
       return a trivial tree with "unparsable" inside *)
+
+  val flat_dt_of_term :
+    vars:Ty.t Var.t list ->
+    T.t ->
+    (T.t, Ty.t) Model.DT.flat_dt
+
+  val simplify_flat_dt : (T.t, Ty.t) Model.DT.flat_dt -> (T.t, Ty.t) Env.t -> (T.t, Ty.t) Model.DT.flat_dt
 
   val problem_kinds : (_,Ty.t) Problem.t -> Model.symbol_kind ID.Map.t
 end

--- a/src/core/FO.mli
+++ b/src/core/FO.mli
@@ -89,6 +89,7 @@ type attr =
 
 (** Statement *)
 type ('t, 'ty) statement =
+  | TyAlias of id * 'ty toplevel_ty * attr list
   | TyDecl of id * int * attr list (** number of arguments *)
   | Decl of id * 'ty toplevel_ty * attr list
   | Axiom of 't

--- a/src/core/Model.ml
+++ b/src/core/Model.ml
@@ -249,6 +249,22 @@ module DT = struct
     in
     check_vars (vars t) t
 
+  (*
+    TODO
+    This algorithm currently takes some flat decision tree with
+    switch
+     | (c11 && c12 && ...) -> body
+     | (c21 && c22 && ...) -> body
+     ...
+    assuming that each cn conjunction only carries one branch over a given variable
+    it then eliminates the variables one by one by pulling that branch out into case statements
+    however we have observed in cvc5 that different things might happen. We can encounter situations
+    where for i != j cni and cnj both bind a variable x. To account for this I propose to
+    check whether a list still contains a binding for a variable after we are done with it and if
+    yes do not yet remove the variable from the set of variables to eliminate. If the models
+    produced by this turn out to be too ugly we can still run some path sensitive data flow analysis
+    to simplify the model afterwards.
+   *)
   (* recursively build a decision tree on the given list of variables *)
   let of_flat (type a) ~equal ~hash fdt =
     let module TTbl = CCHashtbl.Make(struct

--- a/src/core/Model.ml
+++ b/src/core/Model.ml
@@ -249,22 +249,6 @@ module DT = struct
     in
     check_vars (vars t) t
 
-  (*
-    TODO
-    This algorithm currently takes some flat decision tree with
-    switch
-     | (c11 && c12 && ...) -> body
-     | (c21 && c22 && ...) -> body
-     ...
-    assuming that each cn conjunction only carries one branch over a given variable
-    it then eliminates the variables one by one by pulling that branch out into case statements
-    however we have observed in cvc5 that different things might happen. We can encounter situations
-    where for i != j cni and cnj both bind a variable x. To account for this I propose to
-    check whether a list still contains a binding for a variable after we are done with it and if
-    yes do not yet remove the variable from the set of variables to eliminate. If the models
-    produced by this turn out to be too ugly we can still run some path sensitive data flow analysis
-    to simplify the model afterwards.
-   *)
   (* recursively build a decision tree on the given list of variables *)
   let of_flat (type a) ~equal ~hash fdt =
     let module TTbl = CCHashtbl.Make(struct

--- a/src/core/Var.ml
+++ b/src/core/Var.ml
@@ -120,3 +120,9 @@ module Set(Ty : sig type t end) = CCSet.Make(struct
     type t = Ty.t _t
     let compare = compare
   end)
+
+module Map(Ty : sig type t end) = CCMap.Make(struct
+    type 'a _t = 'a t
+    type t = Ty.t _t
+    let compare = compare
+  end)

--- a/src/core/Var.mli
+++ b/src/core/Var.mli
@@ -116,5 +116,6 @@ end
 (** {2 Data structures} *)
 
 module Set(Ty : sig type t end) : CCSet.S with type elt = Ty.t t
+module Map(Ty : sig type t end) : CCMap.S with type key = Ty.t t
 
 

--- a/src/transformations/Elim_ite.ml
+++ b/src/transformations/Elim_ite.ml
@@ -126,6 +126,7 @@ let transform_statement st =
   Utils.debugf ~section 3 "@[<2>transform @{<cyan>statement@}@ `@[%a@]`@]"
     (fun k->k FO.pp_statement st);
   match st with
+    | FO.TyAlias _
     | FO.TyDecl _
     | FO.Decl _
     | FO.CardBound _

--- a/src/transformations/FoToRelational.ml
+++ b/src/transformations/FoToRelational.ml
@@ -347,6 +347,7 @@ let encode_statement state st : FO_rel.form list =
     |> FO_rel.ts_product
   in
   match st with
+    | FO.TyAlias (_, _, _) -> assert false
     | FO.TyDecl (_, 0, attrs) when List.mem FO.Attr_pseudo_prop attrs ->
       []
     | FO.Decl (_, ([], _), attrs) when List.mem FO.Attr_pseudo_true attrs ->

--- a/src/transformations/Trans_fo_tptp.ml
+++ b/src/transformations/Trans_fo_tptp.ml
@@ -87,6 +87,7 @@ module To_tptp = struct
   let conv_form = conv_as_form Var.Subst.empty
 
   let conv_statement st = match st with
+    | FO.TyAlias _ -> assert false
     | TyDecl _
     | Decl _ -> None
     | MutualTypes _ -> errorf_ "@[cannot convert@ statement `@[%a@]`@]" pp_statement st


### PR DESCRIPTION
This PR provides a first integration of Nunchaku with cvc5. The backend is mostly a copy of the CVC4 one with a few key changes:
- The portfolio options were swapped out with new ones that Andy recommended to me. In particular I dropped `uf-ss-fair-monotone` as he pointed out it is not used by default and upon measuring dropping it yielded significantly better results
- We use the new `get-model-domain-elements` function in cvc5 that was introduced specifically for this purpose by Abdal (previously only available in the C++ API)
- cvc5 sometimes prints models that cause us to generate flat decision trees which have contradictory checks on the same variable, for example `x1 = (Succ Zero) && x1 = Zero`. These kinds of FDTs cannot be recovered into ordinary decision trees because the recovery algorithm (and the DT invariants) require that each variable is only checked once per case arm. To counteract this I developed a sort mini-unifier that attempts to detect trivially false branches and erase them before we try to generate a DT from the FDT.

This branch now passes the test suite and is able to solve two additional problems compared to CVC4.